### PR TITLE
Applied modified patch for extra output options

### DIFF
--- a/utilities/diatheke/corediatheke.cpp
+++ b/utilities/diatheke/corediatheke.cpp
@@ -303,77 +303,93 @@ void doquery(unsigned long maxverses = -1, unsigned char outputformat = FMT_PLAI
 			target->setKey(listkey);
 			VerseKey *vk = SWDYNAMIC_CAST(VerseKey, target->getKey());
 			
-			// if we've got a VerseKey (Bible or Commentary)
-			if (vk) {
-				// let's do some special processing if we're at verse 1
-				if (vk->getVerse() == 1) {
-					if (vk->getChapter() == 1) {
-						if (vk->getBook() == 1) {
-							if (vk->getTestament() == 1) {								
-								// MODULE START SPECIAL PROCESSING								
-								if (outputformat == FMT_LATEX)
-									 { *output << "\\swordmodule\n";
-									// put your latex module start stuff here
-								}
-							}
-							// TESTAMENT START SPECIAL PROCESSING
-							if (outputformat == FMT_LATEX) {
-								// put your latex testament start stuff here
-								*output << "\\swordtestament\n";
-							}
-						}
-						// BOOK START SPECIAL PROCESSING
-						if (outputformat == FMT_LATEX) {
-							// put your latex book start stuff here
-							*output << "\\swordbook\n";
-						}
-					}
-					// CHAPTER START SPECIAL PROCESSING
-					if (outputformat == FMT_LATEX) {
-						*output << "\n\\swordchapter{" 
-							<< vk->getOSISRef() << "}{"
-							<< vk->getText() << "}{" 
-							<< vk->getChapter() << "}";
-					}
-				}
+            if (!(optionfilters & OP_NOPRINTREFS)) {
+                // if we've got a VerseKey (Bible or Commentary)
+                if (vk) {
+                    // let's do some special processing if we're at verse 1
+                    if (vk->getVerse() == 1) {
+                        if (vk->getChapter() == 1) {
+                            if (vk->getBook() == 1) {
+                                if (vk->getTestament() == 1) {
+                                    // MODULE START SPECIAL PROCESSING
+                                    if (outputformat == FMT_LATEX)
+                                         { *output << "\\swordmodule\n";
+                                        // put your latex module start stuff here
+                                    }
+                                }
+                                // TESTAMENT START SPECIAL PROCESSING
+                                if (outputformat == FMT_LATEX) {
+                                    // put your latex testament start stuff here
+                                    *output << "\\swordtestament\n";
+                                }
+                            }
+                            // BOOK START SPECIAL PROCESSING
+                            if (outputformat == FMT_LATEX) {
+                                // put your latex book start stuff here
+                                *output << "\\swordbook\n";
+                            }
+                        }
+                        // CHAPTER START SPECIAL PROCESSING
+                        if (outputformat == FMT_LATEX) {
+                            *output << "\n\\swordchapter{"
+                                << vk->getOSISRef() << "}{"
+                                << vk->getText() << "}{"
+                                << vk->getChapter() << "}";
+                        }
+                    }
 
-				// PREVERSE MATTER
-				header = target->getEntryAttributes()["Heading"]["Preverse"]["0"];
-				*output << target->renderText(header);
+                    // PREVERSE MATTER
+                    header = target->getEntryAttributes()["Heading"]["Preverse"]["0"];
+                    *output << target->renderText(header);
 
-				// VERSE PROCESSING
-				if (outputformat == FMT_LATEX) {
-					*output << "\\swordverse{"
-						<< vk->getOSISRef() << "}{"
-						<< vk->getText() << "}{" 
-						<< vk->getVerse() << "} ";
-				}
-				// no special format processing default: just show the key
-				else {
-					*output << target->getKeyText();
-				}
-			}
-			// if we're not a VerseKey, then simply output the key
-			else { 						
-				*output << target->getKeyText();
-			}
+                    // VERSE PROCESSING
+                    if (outputformat == FMT_LATEX) {
+                        *output << "\\swordverse{"
+                            << vk->getOSISRef() << "}{"
+                            << vk->getText() << "}{"
+                            << vk->getVerse() << "} ";
+                    }
+                    // no special format processing default: just show the key
+                    else {
+                        *output << target->getKeyText();
+                    }
+                }
+                // if we're not a VerseKey, then simply output the key
+                else {
+                    *output << target->getKeyText();
+                }
+
+                // Separation between verse reference and text
+                if (outputformat == FMT_HTML || outputformat == FMT_HTMLHREF || outputformat == FMT_XHTML || outputformat == FMT_THML || outputformat == FMT_CGI) {
+                    *output << ": ";
+                }
+                else if (outputformat == FMT_RTF) {
+                    *output << ": ";
+                }
+                else if (outputformat == FMT_LATEX) {
+                    *output << " ";
+                }
+                else {
+                    *output << ": ";
+                }
+            }
 
 			// OUTPUT RENDER ENTRY
-			if (outputformat == FMT_HTML || outputformat == FMT_HTMLHREF || outputformat == FMT_XHTML || outputformat == FMT_THML || outputformat == FMT_CGI) {
-				*output << ": <span ";
-				*output << "style=\"font:"  << font << ";\" ";
-				if (strcmp(modlocale,locale) !=0 ) { *output << "lang=\"" << modlocale << "\"";}
-				*output << ">";
-			}
-			else if (outputformat == FMT_RTF) {
-				*output << ": {\\f1 ";
-			}
-			else if (outputformat == FMT_LATEX) {
-				*output << " ";
-			}
-			else {
-				*output << ": ";
-			}
+            if (outputformat == FMT_HTML || outputformat == FMT_HTMLHREF || outputformat == FMT_XHTML || outputformat == FMT_THML || outputformat == FMT_CGI) {
+                *output << "<span ";
+                *output << "style=\"font:"  << font << ";\" ";
+                if (strcmp(modlocale,locale) !=0 ) { *output << "lang=\"" << modlocale << "\"";}
+                *output << ">";
+            }
+            else if (outputformat == FMT_RTF) {
+                *output << "{\\f1 ";
+            }
+            else if (outputformat == FMT_LATEX) {
+                *output << "";
+            }
+            else {
+                *output << "";
+            }
 					
 			*output << target->renderText();
 			
@@ -385,14 +401,17 @@ void doquery(unsigned long maxverses = -1, unsigned char outputformat = FMT_PLAI
 				*output << "}";
 			}
 
-			if (inputformat != FMT_THML && (outputformat == FMT_HTML || outputformat == FMT_HTMLHREF || outputformat == FMT_XHTML || outputformat == FMT_THML || outputformat == FMT_CGI))
-				*output << "<br />";
-			else if (outputformat == FMT_OSIS)
-				*output << "<milestone type=\"line\"/>";
-			else if (outputformat == FMT_RTF)
-				*output << "\\par ";
-			else if (outputformat == FMT_GBF)
-				*output << "<CM>";
+
+            if (!(optionfilters & OP_NOPRINTNEWLINES)) {
+                if (inputformat != FMT_THML && (outputformat == FMT_HTML || outputformat == FMT_HTMLHREF || outputformat == FMT_XHTML || outputformat == FMT_THML || outputformat == FMT_CGI))
+                    *output << "<br />";
+                else if (outputformat == FMT_OSIS)
+                    *output << "<milestone type=\"line\"/>";
+                else if (outputformat == FMT_RTF)
+                    *output << "\\par ";
+                else if (outputformat == FMT_GBF)
+                    *output << "<CM>";
+            }
 
 			*output << "\n";
 
@@ -403,17 +422,17 @@ void doquery(unsigned long maxverses = -1, unsigned char outputformat = FMT_PLAI
 			*output << "\\end{" << modlanguage << "}\n";
 		}
 		
-		
-		*output << "(";
-		*output << target->getName();
-		
-		if (outputformat == FMT_LATEX) {
-			*output << ", ";
-			*output << target->getConfigEntry("DistributionLicense");
-			
-		}
+	    if (!(optionfilters & OP_NOPRINTMODNAME)) {
+            *output << "(";
+            *output << target->getName();
 
-		*output << ")\n";
+            if (outputformat == FMT_LATEX) {
+                *output << ", ";
+                *output << target->getConfigEntry("DistributionLicense");
+            }
+
+            *output << ")\n";
+        }
 
 		if (outputformat == FMT_RTF) {
 			*output << "}";

--- a/utilities/diatheke/corediatheke.h
+++ b/utilities/diatheke/corediatheke.h
@@ -60,6 +60,9 @@
 #define OP_ENUM (1<<17)
 #define OP_MORPHSEG (1<<18)
 #define OP_INTROS (1<<19)
+#define OP_NOPRINTMODNAME (1<<20)
+#define OP_NOPRINTREFS (1<<21)
+#define OP_NOPRINTNEWLINES (1<<22)
 
 #define ST_NONE 0
 #define ST_REGEX 1     //  0

--- a/utilities/diatheke/diatheke.cpp
+++ b/utilities/diatheke/diatheke.cpp
@@ -41,16 +41,17 @@ void printsyntax() {
 	fprintf (stderr, "Copyright 1999-2014 by the CrossWire Bible Society\n");
 	fprintf (stderr, "http://www.crosswire.org/sword/diatheke/\n");
 	fprintf (stderr, "\n");
-	fprintf (stderr, "usage:  diatheke <-b module_name> [-s search_type] [-r search_range]\n");
+	fprintf (stderr, "usage:  diatheke -b module_name [-s search_type] [-r search_range]\n");
 	fprintf (stderr, "    [-o option_filters] [-m maximum_verses] [-f output_format]\n");
 	fprintf (stderr, "    [-e output_encoding] [-v variant#(-1=all|0|1)]\n");
-	fprintf (stderr, "    [-l locale] <-k query_key>\n");
+    fprintf (stderr, "    [-l locale] [--no-refs] [--no-mod-name] [--no-newlines] -k query_key\n");
 	fprintf (stderr, "\n");
 	fprintf (stderr, "If <book> is \"system\" you may use these system keys: \"modulelist\",\n");
-	fprintf (stderr, "\"modulelistnames\", \"bibliography\", and \"localelist\".");
+	fprintf (stderr, "\"modulelistnames\", \"bibliography\", and \"localelist\".\n");
 	fprintf (stderr, "\n");
-	fprintf (stderr, "Valid search_type values are: phrase , regex, multiword, attribute,\n");
+	fprintf (stderr, "Valid search_type values are: phrase, regex, multiword, attribute,\n");
 	fprintf (stderr, "  lucene, multilemma.\n");
+	fprintf (stderr, "\n");
 	fprintf (stderr, "Valid (output) option_filters values are: n (Strong's numbers),\n");
 	fprintf (stderr, "  f (Footnotes), m (Morphology), h (Section Headings),\n");
 	fprintf (stderr, "  c (Cantillation), v (Hebrew Vowels), a (Greek Accents), p (Arabic Vowels)\n");
@@ -59,14 +60,23 @@ void printsyntax() {
 	fprintf (stderr, "  g (Glosses/Ruby), e (Word Enumerations), i (Intros)\n");
 	fprintf (stderr, "  x (Encoded Transliterations), t (Algorithmic Transliterations via ICU),\n");
 	fprintf (stderr, "  M (morpheme segmentation)\n");
-
-	fprintf (stderr, "Maximum verses may be any integer value\n");
+	fprintf (stderr, "\n");
+	fprintf (stderr, "Maximum verses may be any integer value.\n");
+	fprintf (stderr, "\n");
 	fprintf (stderr, "Valid output_format values are: CGI, GBF, HTML, HTMLHREF, LaTeX, OSIS, RTF,\n");
- 	fprintf (stderr, "  ThML, WEBIF, XHTML, plain, and internal (def)\n");
- 	fprintf (stderr, "The option LaTeX will produce a compilable document, but may well require\n");
+ 	fprintf (stderr, "  ThML, WEBIF, XHTML, plain, and internal (default).\n");
+	fprintf (stderr, "\n");
+ 	fprintf (stderr, "The option LaTeX will produce a compilable document, but it may well require\n");
 	fprintf (stderr, "  tweaking to be usable.\n");
-	fprintf (stderr, "Valid output_encoding values are: Latin1, UTF8 (def), UTF16, HTML, RTF, and SCSU\n");
+	fprintf (stderr, "\n");
+	fprintf (stderr, "Valid output_encoding values are: Latin1, UTF8 (default), UTF16, HTML, RTF, and SCSU.\n");
+	fprintf (stderr, "\n");
 	fprintf (stderr, "Valid locale values depend on installed locales. en is default.\n");
+	fprintf (stderr, "\n");
+	fprintf (stderr, "--no-refs suppresses reference printing in output.\n");
+	fprintf (stderr, "--no-mod-name suppresses the module name in output.\n");
+	fprintf (stderr, "--no-newlines replaces new lines with a space in output.\n");
+	fprintf (stderr, "\n");
 	fprintf (stderr, "The query_key must be the last argument because all following\n");
 	fprintf (stderr, "  arguments are added to the key.\n");
 	fprintf (stderr, "\n");
@@ -283,6 +293,18 @@ int main(int argc, char **argv)
 			}
 		}
 		*/
+		else if (!::stricmp("--no-mod-name", argv[i])) {
+			if (i+1 <= argc)
+				optionfilters |= OP_NOPRINTMODNAME;
+		}
+		else if (!::stricmp("--no-refs", argv[i])) {
+			if (i+1 <= argc)
+				optionfilters |= OP_NOPRINTREFS;
+		}
+		else if (!::stricmp("--no-newlines", argv[i])) {
+			if (i+1 <= argc)
+				optionfilters |= OP_NOPRINTNEWLINES;
+		}
 		else {
 			// unexpected argument, so print the syntax
 			// -h, --help, /?, etc. will trigger this


### PR DESCRIPTION
Added new optional parameters for the `diatheke` command:
* `--no-refs` suppresses reference printing in output
* `--no-mod-name` suppresses the module name in output
* `--no-newlines` replaces new lines with a space in output

I am not the author of these changes; the original diff is here:
http://www.crosswire.org/pipermail/sword-devel/attachments/20130326/5c7fd8bd/attachment.obj

The code base had changed since that diff was created. This PR Implemented identical functional changes, but to the code base in GitHub.